### PR TITLE
Camera-locked (billboard) quad & text instances

### DIFF
--- a/Testing/TinyFFR.Tests/AssemblyTypeLoadOrder.cs
+++ b/Testing/TinyFFR.Tests/AssemblyTypeLoadOrder.cs
@@ -52,6 +52,13 @@ sealed class AssemblyTypeLoadOrderAnchor {
 // Second stage: types that themselves embed a resource struct (the fragile shape described above) load
 // safely here because the first anchor has already forced their embedded resource types to load.
 sealed class AssemblyTypeLoadOrderAnchorStage2 {
+	QuadInstance _quadInstance;
 	TextInstance _textInstance;
+}
+
+// Third stage: types embedding the stage-2 types (one nesting level deeper).
+sealed class AssemblyTypeLoadOrderAnchorStage3 {
+	CameraLockedQuadInstance _cameraLockedQuadInstance;
+	CameraLockedTextInstance _cameraLockedTextInstance;
 }
 #pragma warning restore CS0169

--- a/Testing/TinyFFR.Tests/IntegrationTests/Local/LocalCameraLockedObjectsTest.cs
+++ b/Testing/TinyFFR.Tests/IntegrationTests/Local/LocalCameraLockedObjectsTest.cs
@@ -1,0 +1,80 @@
+// Created on 2026-07-18 by Ben Bowen
+// (c) Egodystonic / TinyFFR 2026
+
+using Egodystonic.TinyFFR.Assets.Local;
+using Egodystonic.TinyFFR.Assets.Materials;
+using Egodystonic.TinyFFR.Assets.Meshes;
+using Egodystonic.TinyFFR.Assets.Text;
+using Egodystonic.TinyFFR.Environment.Input;
+using Egodystonic.TinyFFR.Environment.Local;
+using Egodystonic.TinyFFR.Factory;
+using Egodystonic.TinyFFR.Factory.Local;
+using Egodystonic.TinyFFR.Testing;
+using Egodystonic.TinyFFR.World;
+
+namespace Egodystonic.TinyFFR;
+
+[TestFixture, Explicit]
+class LocalCameraLockedObjectsTest {
+	[SetUp]
+	public void SetUpTest() { }
+
+	[TearDown]
+	public void TearDownTest() { }
+
+	[Test]
+	public void Execute() {
+		// Expected: the left quad always faces the camera exactly; the right quad only spins around the
+		// vertical axis to track the camera; the text should always be readable head-on. All three should
+		// pivot about their anchor points (visible when orbiting: the anchored corner/centre stays put).
+		using var factory = new LocalTinyFfrFactory();
+		var display = factory.DisplayDiscoverer.Primary!.Value;
+		using var window = factory.WindowBuilder.CreateWindow(display, title: "Local Camera-Locked Objects Test (fly around; Esc quits)");
+		using var camera = factory.CameraBuilder.CreateCamera(new Location(0f, 0f, 5f));
+		using var quadMesh = factory.MeshBuilder.CreateQuadMesh(twoSided: true, backSideInvertsTextures: false);
+		using var mat = factory.AssetLoader.MaterialBuilder.CreateTestMaterial();
+		using var font = factory.AssetLoader.LoadFont(CommonTestAssets.FindAsset("DejaVuSans.ttf"));
+		var pen = font.CreatePen(ColorVect.WhiteOpaque, ColorVect.BlackOpaque, 1f);
+		var @string = font.CreateString("Camera-Locked Text");
+
+		using var freeLockedQuad = factory.ObjectBuilder.CreateCameraLockedQuadInstance(
+			quadMesh, mat,
+			position: new Location(-2f, 0f, 0f),
+			size: new XYPair<float>(1.5f, 1f),
+			positionAnchor: Orientation2D.DownLeft
+		);
+		using var axisLockedQuad = factory.ObjectBuilder.CreateCameraLockedQuadInstance(
+			quadMesh, mat,
+			position: new Location(2f, 0f, 0f),
+			size: new XYPair<float>(1.5f, 1f),
+			lockedAxis: Direction.Up
+		);
+		using var lockedText = factory.ObjectBuilder.CreateCameraLockedTextInstance(
+			pen, @string,
+			position: new Location(0f, 2f, 0f),
+			textInstanceHeight: 0.3f
+		);
+
+		using var scene = factory.SceneBuilder.CreateScene(BuiltInSceneBackdrop.Clouds);
+		scene.Add(freeLockedQuad);
+		scene.Add(axisLockedQuad);
+		scene.Add(lockedText);
+		using var renderer = factory.RendererBuilder.CreateRenderer(scene, camera, window);
+		using var camController = camera.CreateController<FreeFlyingCameraController>();
+
+		using var loop = factory.ApplicationLoopBuilder.CreateLoop();
+		while (!loop.Input.UserQuitRequested && !loop.Input.KeyboardAndMouse.KeyIsCurrentlyDown(KeyboardOrMouseKey.Escape)) {
+			var dt = loop.IterateOnce().AsDeltaTime();
+
+			DefaultCameraInputHandler.TickKbm(loop.Input.KeyboardAndMouse, camController, dt, window);
+			DefaultCameraInputHandler.TickGamepad(loop.Input.GameControllersCombined, camController, dt);
+			DefaultCameraInputHandler.Progress(camController, dt);
+
+			renderer.Render();
+		}
+
+		scene.Remove(freeLockedQuad);
+		scene.Remove(axisLockedQuad);
+		scene.Remove(lockedText);
+	}
+}

--- a/Testing/TinyFFR.Tests/Rendering/BindableRendererTestFakes.cs
+++ b/Testing/TinyFFR.Tests/Rendering/BindableRendererTestFakes.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using Egodystonic.TinyFFR.Assets.Materials;
+using Egodystonic.TinyFFR.Assets.Meshes;
+using Egodystonic.TinyFFR.Assets.Text;
 using Egodystonic.TinyFFR.Environment.Local;
 using Egodystonic.TinyFFR.Factory;
 using Egodystonic.TinyFFR.Resources;
@@ -255,6 +257,10 @@ sealed class FakeSceneImplProvider : ISceneImplProvider {
 	public void Remove(ResourceHandle<Scene> handle, ModelInstanceGroup modelInstanceGroup) { }
 	public void Add<TLight>(ResourceHandle<Scene> handle, TLight light) where TLight : ILight<TLight> { }
 	public void Remove<TLight>(ResourceHandle<Scene> handle, TLight light) where TLight : ILight<TLight> { }
+	public void Add(ResourceHandle<Scene> handle, CameraLockedQuadInstance quad) { }
+	public void Remove(ResourceHandle<Scene> handle, CameraLockedQuadInstance quad) { }
+	public void Add(ResourceHandle<Scene> handle, CameraLockedTextInstance text) { }
+	public void Remove(ResourceHandle<Scene> handle, CameraLockedTextInstance text) { }
 
 	public void SetBackdrop(ResourceHandle<Scene> handle, BuiltInSceneBackdrop backdrop, float indirectLightingIntensity, Rotation rotation) { }
 	public void SetBackdrop(ResourceHandle<Scene> handle, BackdropTexture backdrop, float indirectLightingIntensity, Rotation rotation) { }

--- a/Testing/TinyFFR.Tests/World/CameraLockedObjects.cs
+++ b/Testing/TinyFFR.Tests/World/CameraLockedObjects.cs
@@ -1,0 +1,122 @@
+// Created on 2026-07-18 by Ben Bowen
+// (c) Egodystonic / TinyFFR 2026
+
+using Egodystonic.TinyFFR.Assets.Meshes;
+
+namespace Egodystonic.TinyFFR.World;
+
+[TestFixture]
+class CameraLockedObjectsTest {
+	const float TestTolerance = 1E-3f;
+	static readonly XYPair<float> TestSize = new(3f, 2f);
+	static readonly Location TestPosition = new(1f, 2f, 3f);
+	static readonly Location TestCameraPosition = new(-4f, 7f, 12f);
+
+	static readonly Orientation2D[] AllAnchors = [
+		Orientation2D.None, Orientation2D.Right, Orientation2D.UpRight, Orientation2D.Up, Orientation2D.UpLeft,
+		Orientation2D.Left, Orientation2D.DownLeft, Orientation2D.Down, Orientation2D.DownRight
+	];
+
+	[SetUp]
+	public void SetUpTest() { }
+
+	[TearDown]
+	public void TearDownTest() { }
+
+	static Transform CreateCanonicalQuadTransform(Orientation2D anchor) {
+		return QuadMesh.CalculateTransformForStandardQuadMesh(TestPosition, TestSize, Direction.Forward, Direction.Up, anchor);
+	}
+
+	[Test]
+	public void AnchorOffsetHelperShouldMatchTransformCalculatorBaking() {
+		foreach (var anchor in AllAnchors) {
+			var facing = new Direction(1f, 1f, 0.5f);
+			var transform = QuadMesh.CalculateTransformForStandardQuadMesh(TestPosition, TestSize, facing, null, anchor);
+			var offset = QuadMesh.CalculateAnchorOffsetForStandardQuadMesh(TestSize, anchor);
+			AssertToleranceEquals(TestPosition.AsVect() + offset * transform.Rotation, transform.Translation, TestTolerance);
+		}
+	}
+
+	[Test]
+	public void FreeBillboardShouldFaceCameraPosition() {
+		foreach (var anchor in AllAnchors) {
+			var curTransform = CreateCanonicalQuadTransform(anchor);
+			var offset = QuadMesh.CalculateAnchorOffsetForStandardQuadMesh(TestSize, anchor);
+
+			Assert.IsTrue(LocalSceneBuilder.TryCalculateCameraLockedTransform(curTransform, offset, Direction.Forward, Direction.None, TestCameraPosition, Direction.Up, out var result));
+
+			var expectedFacing = TestPosition.DirectionTo(TestCameraPosition);
+			AssertToleranceEquals(expectedFacing, Direction.Forward * result.Rotation, TestTolerance);
+			AssertToleranceEquals(curTransform.Scaling, result.Scaling, TestTolerance);
+		}
+	}
+
+	[Test]
+	public void TextCanonicalFacingShouldPointTowardCamera() {
+		var curTransform = CreateCanonicalQuadTransform(Orientation2D.None);
+		var offset = QuadMesh.CalculateAnchorOffsetForStandardQuadMesh(TestSize, Orientation2D.None);
+
+		Assert.IsTrue(LocalSceneBuilder.TryCalculateCameraLockedTransform(curTransform, offset, Direction.Backward, Direction.None, TestCameraPosition, Direction.Up, out var result));
+
+		AssertToleranceEquals(TestPosition.DirectionTo(TestCameraPosition), Direction.Backward * result.Rotation, TestTolerance);
+	}
+
+	[Test]
+	public void BillboardRotationShouldKeepAnchorPointStationary() {
+		foreach (var anchor in AllAnchors) {
+			var curTransform = CreateCanonicalQuadTransform(anchor);
+			var offset = QuadMesh.CalculateAnchorOffsetForStandardQuadMesh(TestSize, anchor);
+
+			Assert.IsTrue(LocalSceneBuilder.TryCalculateCameraLockedTransform(curTransform, offset, Direction.Forward, Direction.None, TestCameraPosition, Direction.Up, out var result));
+			AssertToleranceEquals(TestPosition.AsVect(), result.Translation - offset * result.Rotation, TestTolerance);
+
+			// Second tick from a different camera position must still pivot about the same anchor point
+			var secondCameraPosition = new Location(20f, -6f, 1f);
+			Assert.IsTrue(LocalSceneBuilder.TryCalculateCameraLockedTransform(result, offset, Direction.Forward, Direction.None, secondCameraPosition, Direction.Up, out var secondResult));
+			AssertToleranceEquals(TestPosition.AsVect(), secondResult.Translation - offset * secondResult.Rotation, TestTolerance);
+		}
+	}
+
+	[Test]
+	public void AxisLockedBillboardShouldPreserveAxisAndFaceCameraAsCloselyAsPossible() {
+		var lockedAxis = Direction.Up;
+		foreach (var anchor in AllAnchors) {
+			var curTransform = CreateCanonicalQuadTransform(anchor);
+			var offset = QuadMesh.CalculateAnchorOffsetForStandardQuadMesh(TestSize, anchor);
+
+			Assert.IsTrue(LocalSceneBuilder.TryCalculateCameraLockedTransform(curTransform, offset, Direction.Forward, lockedAxis, TestCameraPosition, Direction.Up, out var result));
+
+			AssertToleranceEquals(lockedAxis, Direction.Up * result.Rotation, TestTolerance);
+			var expectedFacing = TestPosition.DirectionTo(TestCameraPosition).OrthogonalizedAgainst(lockedAxis);
+			Assert.IsNotNull(expectedFacing);
+			AssertToleranceEquals(expectedFacing.Value, Direction.Forward * result.Rotation, TestTolerance);
+		}
+	}
+
+	[Test]
+	public void ShouldSkipDegenerateConfigurations() {
+		var curTransform = CreateCanonicalQuadTransform(Orientation2D.None);
+		var offset = QuadMesh.CalculateAnchorOffsetForStandardQuadMesh(TestSize, Orientation2D.None);
+
+		// Camera exactly at the anchor point
+		Assert.IsFalse(LocalSceneBuilder.TryCalculateCameraLockedTransform(curTransform, offset, Direction.Forward, Direction.None, TestPosition, Direction.Up, out var unchanged));
+		AssertToleranceEquals(curTransform, unchanged, TestTolerance);
+
+		// Camera directly along the locked axis
+		var cameraAlongAxis = TestPosition + Direction.Up * 10f;
+		Assert.IsFalse(LocalSceneBuilder.TryCalculateCameraLockedTransform(curTransform, offset, Direction.Forward, Direction.Up, cameraAlongAxis, Direction.Up, out unchanged));
+		AssertToleranceEquals(curTransform, unchanged, TestTolerance);
+	}
+
+	[Test]
+	public void ShouldBeStableAcrossRepeatedTicks() {
+		foreach (var anchor in AllAnchors) {
+			var curTransform = CreateCanonicalQuadTransform(anchor);
+			var offset = QuadMesh.CalculateAnchorOffsetForStandardQuadMesh(TestSize, anchor);
+
+			Assert.IsTrue(LocalSceneBuilder.TryCalculateCameraLockedTransform(curTransform, offset, Direction.Forward, Direction.None, TestCameraPosition, Direction.Up, out var firstResult));
+			Assert.IsTrue(LocalSceneBuilder.TryCalculateCameraLockedTransform(firstResult, offset, Direction.Forward, Direction.None, TestCameraPosition, Direction.Up, out var secondResult));
+			AssertToleranceEquals(firstResult, secondResult, TestTolerance);
+		}
+	}
+}

--- a/TinyFFR/Assets/Meshes/QuadMesh.cs
+++ b/TinyFFR/Assets/Meshes/QuadMesh.cs
@@ -157,3 +157,83 @@ public readonly struct QuadInstance : IDisposable, IStringSpanNameEnabled, IEqua
 	public static bool operator !=(QuadInstance left, QuadInstance right) => !left.Equals(right);
 	#endregion
 }
+
+public readonly struct CameraLockedQuadInstance : IDisposable, IStringSpanNameEnabled, IEquatable<CameraLockedQuadInstance>, IScaledSceneObject, IPositionedSceneObject, IMaterialUsingSceneObject {
+	public QuadInstance UnderlyingQuadInstance { get; }
+	public Direction LockedAxis { get; }
+
+	public CameraLockedQuadInstance(QuadInstance underlyingQuadInstance, Direction lockedAxis) {
+		UnderlyingQuadInstance = underlyingQuadInstance;
+		LockedAxis = lockedAxis;
+	}
+	
+	public Location Position {
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => UnderlyingQuadInstance.Position;
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		set => UnderlyingQuadInstance.SetPosition(value);
+	}
+	[MethodImpl(MethodImplOptions.AggressiveInlining)] // Method can be obsoleted and ultimately removed once https://github.com/dotnet/roslyn/issues/45284 is fixed
+	public void SetPosition(Location position) => Position = position;
+
+	public Vect Scaling {
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => UnderlyingQuadInstance.Scaling;
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		set => UnderlyingQuadInstance.SetScaling(value);
+	}
+	[MethodImpl(MethodImplOptions.AggressiveInlining)] // Method can be obsoleted and ultimately removed once https://github.com/dotnet/roslyn/issues/45284 is fixed
+	public void SetScaling(Vect scaling) => Scaling = scaling;
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void SetScaling(float uniformScaling) => Scaling = new Vect(uniformScaling);
+	
+	public Material? Material {
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => UnderlyingQuadInstance.Material;
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		set => UnderlyingQuadInstance.SetMaterial(value);
+	}
+	[MethodImpl(MethodImplOptions.AggressiveInlining)] // Method can be obsoleted and ultimately removed once https://github.com/dotnet/roslyn/issues/45284 is fixed
+	public void SetMaterial(Material? material) => Material = material;
+
+	public MaterialEffectController? MaterialEffects {
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => UnderlyingQuadInstance.MaterialEffects;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public string GetNameAsNewStringObject() => UnderlyingQuadInstance.GetNameAsNewStringObject();
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int GetNameLength() => UnderlyingQuadInstance.GetNameLength();
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void CopyName(Span<char> destinationBuffer) => UnderlyingQuadInstance.CopyName(destinationBuffer);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void MoveBy(Vect translation) => UnderlyingQuadInstance.MoveBy(translation);
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void ScaleBy(float scalar) => UnderlyingQuadInstance.ScaleBy(scalar);
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void ScaleBy(Vect vect) => UnderlyingQuadInstance.ScaleBy(vect);
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void AdjustScaleBy(float scalar) => UnderlyingQuadInstance.AdjustScaleBy(scalar);
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void AdjustScaleBy(Vect vect) => UnderlyingQuadInstance.AdjustScaleBy(vect);
+	
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void SetNullMaterialBaseColor(ColorVect baseColor) => UnderlyingQuadInstance.SetNullMaterialBaseColor(baseColor);
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void SetNullMaterialShadingStyle(NullMaterialShadingStyle style) => UnderlyingQuadInstance.SetNullMaterialShadingStyle(style);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Dispose() => UnderlyingQuadInstance.Dispose();
+
+	public override string ToString() => UnderlyingQuadInstance.ToString();
+
+	#region Equality
+	public bool Equals(CameraLockedQuadInstance other) => UnderlyingQuadInstance.Equals(other.UnderlyingQuadInstance);
+	public override bool Equals(object? obj) => obj is CameraLockedQuadInstance other && Equals(other);
+	public override int GetHashCode() => UnderlyingQuadInstance.GetHashCode();
+	public static bool operator ==(CameraLockedQuadInstance left, CameraLockedQuadInstance right) => left.Equals(right);
+	public static bool operator !=(CameraLockedQuadInstance left, CameraLockedQuadInstance right) => !left.Equals(right);
+	#endregion
+}

--- a/TinyFFR/Assets/Meshes/QuadMesh.cs
+++ b/TinyFFR/Assets/Meshes/QuadMesh.cs
@@ -18,16 +18,19 @@ public readonly struct QuadMesh : IDisposable, IStringSpanNameEnabled, IEquatabl
 
 	public static Transform CalculateTransformForStandardQuadMesh(Location position, XYPair<float> size, Direction facingDirection, Direction? uprightDirection = null, Orientation2D positionAnchor = Orientation2D.None) {
 		// Quad meshes are built as 1x1 squares on the XY plane facing forward with up being the upright direction by the IMeshBuilder default implementation
-		
+
 		var rotation = Rotation.FromStartAndEndOrientation(Direction.Forward, Direction.Up, facingDirection, uprightDirection ?? Direction.Up);
-		
-		var translatedAnchorPoint = UiUtils.TranslateAnchoredCanvasOffsetNormalized(DiagonalOrientation2D.DownLeft, positionAnchor) * -size;
-		
+
 		return new Transform(
-			translation: (new Vect(translatedAnchorPoint.X, translatedAnchorPoint.Y, 0f) * rotation) + position.AsVect(),
+			translation: (CalculateAnchorOffsetForStandardQuadMesh(size, positionAnchor) * rotation) + position.AsVect(),
 			rotation: rotation,
 			scaling: new Vect(size.X, size.Y, 1f)
 		);
+	}
+
+	public static Vect CalculateAnchorOffsetForStandardQuadMesh(XYPair<float> size, Orientation2D positionAnchor) {
+		var translatedAnchorPoint = UiUtils.TranslateAnchoredCanvasOffsetNormalized(DiagonalOrientation2D.DownLeft, positionAnchor) * -size;
+		return new Vect(translatedAnchorPoint.X, translatedAnchorPoint.Y, 0f);
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -161,10 +164,12 @@ public readonly struct QuadInstance : IDisposable, IStringSpanNameEnabled, IEqua
 public readonly struct CameraLockedQuadInstance : IDisposable, IStringSpanNameEnabled, IEquatable<CameraLockedQuadInstance>, IScaledSceneObject, IPositionedSceneObject, IMaterialUsingSceneObject {
 	public QuadInstance UnderlyingQuadInstance { get; }
 	public Direction LockedAxis { get; }
+	public Orientation2D PositionAnchor { get; }
 
-	public CameraLockedQuadInstance(QuadInstance underlyingQuadInstance, Direction lockedAxis) {
+	public CameraLockedQuadInstance(QuadInstance underlyingQuadInstance, Direction lockedAxis, Orientation2D positionAnchor) {
 		UnderlyingQuadInstance = underlyingQuadInstance;
 		LockedAxis = lockedAxis;
+		PositionAnchor = positionAnchor;
 	}
 	
 	public Location Position {

--- a/TinyFFR/Assets/Text/CameraLockedTextInstance.cs
+++ b/TinyFFR/Assets/Text/CameraLockedTextInstance.cs
@@ -1,0 +1,90 @@
+// Created on 2026-07-18 by Ben Bowen
+// (c) Egodystonic / TinyFFR 2026
+
+using Egodystonic.TinyFFR.Assets.Materials;
+using Egodystonic.TinyFFR.Assets.Meshes;
+using Egodystonic.TinyFFR.Resources.Memory;
+using Egodystonic.TinyFFR.World;
+
+namespace Egodystonic.TinyFFR.Assets.Text;
+
+public readonly struct CameraLockedTextInstance : IDisposable, IStringSpanNameEnabled, IEquatable<CameraLockedTextInstance>, IScaledSceneObject, IPositionedSceneObject {
+	public TextInstance UnderlyingTextInstance { get; }
+	public Direction LockedAxis { get; }
+	public Orientation2D PositionAnchor { get; }
+
+	public CameraLockedTextInstance(TextInstance underlyingTextInstance, Direction lockedAxis, Orientation2D positionAnchor) {
+		UnderlyingTextInstance = underlyingTextInstance;
+		LockedAxis = lockedAxis;
+		PositionAnchor = positionAnchor;
+	}
+
+	public FontPen Pen {
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => UnderlyingTextInstance.Pen;
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		set => UnderlyingTextInstance.SetPen(value);
+	}
+	[MethodImpl(MethodImplOptions.AggressiveInlining)] // Method can be obsoleted and ultimately removed once https://github.com/dotnet/roslyn/issues/45284 is fixed
+	public void SetPen(FontPen pen) => Pen = pen;
+
+	public FontString String {
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => UnderlyingTextInstance.String;
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		set => UnderlyingTextInstance.SetString(value);
+	}
+	[MethodImpl(MethodImplOptions.AggressiveInlining)] // Method can be obsoleted and ultimately removed once https://github.com/dotnet/roslyn/issues/45284 is fixed
+	public void SetString(FontString @string) => String = @string;
+
+	public Location Position {
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => UnderlyingTextInstance.Position;
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		set => UnderlyingTextInstance.SetPosition(value);
+	}
+	[MethodImpl(MethodImplOptions.AggressiveInlining)] // Method can be obsoleted and ultimately removed once https://github.com/dotnet/roslyn/issues/45284 is fixed
+	public void SetPosition(Location position) => Position = position;
+
+	public Vect Scaling {
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => UnderlyingTextInstance.Scaling;
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		set => UnderlyingTextInstance.SetScaling(value);
+	}
+	[MethodImpl(MethodImplOptions.AggressiveInlining)] // Method can be obsoleted and ultimately removed once https://github.com/dotnet/roslyn/issues/45284 is fixed
+	public void SetScaling(Vect scaling) => Scaling = scaling;
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void SetScaling(float uniformScaling) => Scaling = new Vect(uniformScaling);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public string GetNameAsNewStringObject() => UnderlyingTextInstance.GetNameAsNewStringObject();
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int GetNameLength() => UnderlyingTextInstance.GetNameLength();
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void CopyName(Span<char> destinationBuffer) => UnderlyingTextInstance.CopyName(destinationBuffer);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void MoveBy(Vect translation) => UnderlyingTextInstance.MoveBy(translation);
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void ScaleBy(float scalar) => UnderlyingTextInstance.ScaleBy(scalar);
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void ScaleBy(Vect vect) => UnderlyingTextInstance.ScaleBy(vect);
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void AdjustScaleBy(float scalar) => UnderlyingTextInstance.AdjustScaleBy(scalar);
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void AdjustScaleBy(Vect vect) => UnderlyingTextInstance.AdjustScaleBy(vect);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Dispose() => UnderlyingTextInstance.Dispose();
+
+	public override string ToString() => UnderlyingTextInstance.ToString();
+
+	#region Equality
+	public bool Equals(CameraLockedTextInstance other) => UnderlyingTextInstance.Equals(other.UnderlyingTextInstance);
+	public override bool Equals(object? obj) => obj is CameraLockedTextInstance other && Equals(other);
+	public override int GetHashCode() => UnderlyingTextInstance.GetHashCode();
+	public static bool operator ==(CameraLockedTextInstance left, CameraLockedTextInstance right) => left.Equals(right);
+	public static bool operator !=(CameraLockedTextInstance left, CameraLockedTextInstance right) => !left.Equals(right);
+	#endregion
+}

--- a/TinyFFR/Assets/Text/Font.cs
+++ b/TinyFFR/Assets/Text/Font.cs
@@ -57,6 +57,11 @@ public readonly struct Font : IDisposableResource<Font, IFontImplProvider> {
 		return Implementation.GetTextInstanceTransform(_handle, textInstanceWidth, textInstanceHeight, stringSize, position, facingDirection, uprightDirection ?? Direction.Up.OrthogonalizedAgainst(facingDirection) ?? facingDirection.AnyOrthogonal(), positionAnchor, rescaleHeightAccordingToLineCount);
 	}
 
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public Vect GetTextInstanceAnchorOffset(XYPair<float> stringSize, XYPair<float> scaling, Orientation2D positionAnchor) {
+		return Implementation.GetTextInstanceAnchorOffset(_handle, stringSize, scaling, positionAnchor);
+	}
+
 	#region Disposal
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Dispose() => Implementation.Dispose(_handle);

--- a/TinyFFR/Assets/Text/IFontImplProvider.cs
+++ b/TinyFFR/Assets/Text/IFontImplProvider.cs
@@ -18,4 +18,5 @@ public interface IFontImplProvider : IDisposableResourceImplProvider<Font> {
 	void DisposePen(ResourceHandle<Font> handle, nuint penHandle);
 	void DisposeString(ResourceHandle<Font> handle, nuint stringHandle);
 	Transform GetTextInstanceTransform(ResourceHandle<Font> handle, float? textInstanceWidth, float? textInstanceHeight, XYPair<float> stringSize, Location position, Direction facingDirection, Direction uprightDirection, Orientation2D positionAnchor, bool rescaleHeightAccordingToLineCount);
+	Vect GetTextInstanceAnchorOffset(ResourceHandle<Font> handle, XYPair<float> stringSize, XYPair<float> scaling, Orientation2D positionAnchor);
 }

--- a/TinyFFR/Assets/Text/LocalFontLoader.cs
+++ b/TinyFFR/Assets/Text/LocalFontLoader.cs
@@ -626,22 +626,28 @@ sealed unsafe class LocalFontLoader : IFontImplProvider, IResourceDirectory<Font
 		};
 		
 		var rotation = Rotation.FromStartAndEndOrientation(Direction.Backward, Direction.Up, facingDirection, uprightDirection, enforceOrthogonality: false);
-		var horizontalTranslation = (Direction.Left * rotation) * positionAnchor.GetHorizontalComponent() switch {
+
+		return new Transform(
+			translation: position.AsVect() + GetTextInstanceAnchorOffset(handle, stringSize, scaling, positionAnchor) * rotation,
+			rotation: rotation,
+			scaling: new Vect(scaling.X, scaling.Y, 1f)
+		);
+	}
+
+	public Vect GetTextInstanceAnchorOffset(ResourceHandle<Font> handle, XYPair<float> stringSize, XYPair<float> scaling, Orientation2D positionAnchor) {
+		ThrowIfThisOrHandleIsDisposed(handle);
+		var fontData = _activeFonts[handle];
+		var horizontalOffset = Direction.Left * positionAnchor.GetHorizontalComponent() switch {
 			HorizontalOrientation2D.Right => stringSize.X * scaling.X,
 			HorizontalOrientation2D.Left => 0f,
 			_ => stringSize.X * scaling.X * 0.5f
 		};
-		var verticalTranslation = (Direction.Down * rotation) * positionAnchor.GetVerticalComponent() switch {
+		var verticalOffset = Direction.Down * positionAnchor.GetVerticalComponent() switch {
 			VerticalOrientation2D.Up => fontData.Ascent * scaling.Y,
 			VerticalOrientation2D.Down => (fontData.Ascent - stringSize.Y) * scaling.Y,
 			_ => (fontData.Ascent - fontData.Descent - stringSize.Y) * 0.5f * scaling.Y
 		};
-		
-		return new Transform(
-			translation: position.AsVect() + horizontalTranslation + verticalTranslation,
-			rotation: rotation,
-			scaling: new Vect(scaling.X, scaling.Y, 1f)
-		);
+		return horizontalOffset + verticalOffset;
 	}
 	
 	public string GetNameAsNewStringObject(ResourceHandle<Font> handle) {

--- a/TinyFFR/Rendering/Local/LocalRendererBuilder.cs
+++ b/TinyFFR/Rendering/Local/LocalRendererBuilder.cs
@@ -954,6 +954,8 @@ sealed class LocalRendererBuilder : IRendererBuilder, IRendererImplProvider, IRe
 		var localSceneImpl = (LocalSceneBuilder) scene.Implementation;
 		var sceneHandle = scene.GetHandleWithoutDisposeCheck();
 
+		localSceneImpl.PrepareCameraLockedObjectsForRender(sceneHandle, _loadedRenderers[handle].Camera);
+
 		// Currently in filament the cascade count only really affects directional lights, but we set values anyway in case that changes one day
 		switch (quality) {
 			case Quality.VeryLow:

--- a/TinyFFR/Resources/Memory/ObjectPool.cs
+++ b/TinyFFR/Resources/Memory/ObjectPool.cs
@@ -107,3 +107,27 @@ sealed unsafe class MapPool<TKey, TValue> : IDisposable {
 
 	public void Dispose() => _objectPool.Dispose();
 }
+
+sealed unsafe class SetPool<T> : IDisposable {
+	readonly bool _zeroMemoryOnReturn;
+	readonly ObjectPool<ArrayPoolBackedSet<T>> _objectPool;
+
+	public SetPool(bool zeroMemoryOnReturn, int initialPoolCount = ArrayPoolBackedVector<SetPool<T>>.DefaultInitialCapacity) : this(zeroMemoryOnReturn, &CreateNewSet, initialPoolCount) { }
+
+	public SetPool(bool zeroMemoryOnReturn, delegate*<ArrayPoolBackedSet<T>> newItemCreationFunc, int initialPoolCount = ArrayPoolBackedVector<SetPool<T>>.DefaultInitialCapacity) {
+		_zeroMemoryOnReturn = zeroMemoryOnReturn;
+		_objectPool = new(newItemCreationFunc, initialPoolCount);
+	}
+
+	static ArrayPoolBackedSet<T> CreateNewSet() => new();
+
+	public ArrayPoolBackedSet<T> Rent() => _objectPool.Rent();
+
+	public void Return(ArrayPoolBackedSet<T> item) {
+		if (_zeroMemoryOnReturn) item.Clear();
+		else item.ClearWithoutZeroingMemory();
+		_objectPool.Return(item);
+	}
+
+	public void Dispose() => _objectPool.Dispose();
+}

--- a/TinyFFR/World/ISceneImplProvider.cs
+++ b/TinyFFR/World/ISceneImplProvider.cs
@@ -3,6 +3,8 @@
 
 using System;
 using Egodystonic.TinyFFR.Assets.Materials;
+using Egodystonic.TinyFFR.Assets.Meshes;
+using Egodystonic.TinyFFR.Assets.Text;
 using Egodystonic.TinyFFR.Rendering;
 using Egodystonic.TinyFFR.Resources;
 using static Egodystonic.TinyFFR.World.Scene;

--- a/TinyFFR/World/ISceneImplProvider.cs
+++ b/TinyFFR/World/ISceneImplProvider.cs
@@ -21,6 +21,12 @@ public interface ISceneImplProvider : IDisposableResourceImplProvider<Scene> {
 	void Add<TLight>(ResourceHandle<Scene> handle, TLight light) where TLight : ILight<TLight>;
 	void Remove<TLight>(ResourceHandle<Scene> handle, TLight light) where TLight : ILight<TLight>;
 
+	void Add(ResourceHandle<Scene> handle, CameraLockedQuadInstance quad);
+	void Remove(ResourceHandle<Scene> handle, CameraLockedQuadInstance quad);
+
+	void Add(ResourceHandle<Scene> handle, CameraLockedTextInstance text);
+	void Remove(ResourceHandle<Scene> handle, CameraLockedTextInstance text);
+
 	void SetBackdrop(ResourceHandle<Scene> handle, BuiltInSceneBackdrop backdrop, float indirectLightingIntensity, Rotation rotation);
 	void SetBackdrop(ResourceHandle<Scene> handle, BackdropTexture backdrop, float indirectLightingIntensity, Rotation rotation);
 	void SetBackdrop(ResourceHandle<Scene> handle, ColorVect color, float indirectLightingIntensity);

--- a/TinyFFR/World/LocalSceneBuilder.cs
+++ b/TinyFFR/World/LocalSceneBuilder.cs
@@ -23,11 +23,11 @@ sealed unsafe class LocalSceneBuilder : ISceneBuilder, ISceneImplProvider, IReso
 	
 	readonly ArrayPoolBackedVector<ResourceHandle<Scene>> _activeSceneHandles = new();
 	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, ArrayPoolBackedSet<ModelInstance>> _modelInstanceMap = new();
-	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, ArrayPoolBackedSet<QuadInstance>> _cameraLockedQuadInstanceMap = new();
-	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, ArrayPoolBackedSet<TextInstance>> _cameraLockedTextInstanceMap = new();
+	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, ArrayPoolBackedSet<CameraLockedQuadInstance>> _cameraLockedQuadInstanceMap = new();
+	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, ArrayPoolBackedSet<CameraLockedTextInstance>> _cameraLockedTextInstanceMap = new();
 	readonly SetPool<ModelInstance> _modelInstanceSetPool;
-	readonly SetPool<QuadInstance> _quadInstanceSetPool;
-	readonly SetPool<TextInstance> _textInstanceSetPool;
+	readonly SetPool<CameraLockedQuadInstance> _quadInstanceSetPool;
+	readonly SetPool<CameraLockedTextInstance> _textInstanceSetPool;
 	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, ArrayPoolBackedSet<Light>> _lightMap = new();
 	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, Quality> _shadowQualityActivePresetMap = new();
 	readonly SetPool<Light> _lightSetPool;
@@ -107,7 +107,23 @@ sealed unsafe class LocalSceneBuilder : ISceneBuilder, ISceneImplProvider, IReso
 			modelInstance.Handle
 		).ThrowIfFailure();
 
+		EvictFromCameraLockedSets(handle, modelInstance);
 		_globals.DependencyTracker.DeregisterDependency(HandleToInstance(handle), modelInstance);
+	}
+
+	void EvictFromCameraLockedSets(ResourceHandle<Scene> handle, ModelInstance modelInstance) {
+		var lockedQuadSet = _cameraLockedQuadInstanceMap[handle];
+		foreach (var lockedQuad in lockedQuadSet) {
+			if (lockedQuad.UnderlyingQuadInstance.UnderlyingModelInstance != modelInstance) continue;
+			lockedQuadSet.Remove(lockedQuad);
+			break;
+		}
+		var lockedTextSet = _cameraLockedTextInstanceMap[handle];
+		foreach (var lockedText in lockedTextSet) {
+			if (lockedText.UnderlyingTextInstance.UnderlyingModelInstance != modelInstance) continue;
+			lockedTextSet.Remove(lockedText);
+			break;
+		}
 	}
 
 	public void Add(ResourceHandle<Scene> handle, ModelInstanceGroup modelInstanceGroup) {
@@ -372,14 +388,92 @@ sealed unsafe class LocalSceneBuilder : ISceneBuilder, ISceneImplProvider, IReso
 	#endregion
 	
 	#region Camera-Locked Objects
+	public void Add(ResourceHandle<Scene> handle, CameraLockedQuadInstance quad) {
+		ThrowIfThisOrHandleIsDisposed(handle);
+		var instanceSet = _cameraLockedQuadInstanceMap[handle];
+		if (instanceSet.Contains(quad)) return;
+
+		Add(handle, quad.UnderlyingQuadInstance.UnderlyingModelInstance);
+		instanceSet.Add(quad);
+	}
+	public void Remove(ResourceHandle<Scene> handle, CameraLockedQuadInstance quad) {
+		ThrowIfThisOrHandleIsDisposed(handle);
+		// Eviction from the camera-locked set happens in Remove(handle, ModelInstance)
+		Remove(handle, quad.UnderlyingQuadInstance.UnderlyingModelInstance);
+	}
+
+	public void Add(ResourceHandle<Scene> handle, CameraLockedTextInstance text) {
+		ThrowIfThisOrHandleIsDisposed(handle);
+		var instanceSet = _cameraLockedTextInstanceMap[handle];
+		if (instanceSet.Contains(text)) return;
+
+		Add(handle, text.UnderlyingTextInstance.UnderlyingModelInstance);
+		instanceSet.Add(text);
+	}
+	public void Remove(ResourceHandle<Scene> handle, CameraLockedTextInstance text) {
+		ThrowIfThisOrHandleIsDisposed(handle);
+		// Eviction from the camera-locked set happens in Remove(handle, ModelInstance)
+		Remove(handle, text.UnderlyingTextInstance.UnderlyingModelInstance);
+	}
+
 	public void PrepareCameraLockedObjectsForRender(ResourceHandle<Scene> handle, Camera targetCamera) {
-		foreach (var quad in _cameraLockedQuadInstanceMap[handle]) {
-			quad.
+		ThrowIfThisOrHandleIsDisposed(handle);
+		var lockedQuadSet = _cameraLockedQuadInstanceMap[handle];
+		var lockedTextSet = _cameraLockedTextInstanceMap[handle];
+		if (lockedQuadSet.Count == 0 && lockedTextSet.Count == 0) return;
+
+		var cameraPosition = targetCamera.Position;
+		var cameraUpDirection = targetCamera.UpDirection;
+
+		foreach (var quad in lockedQuadSet) {
+			var curTransform = quad.UnderlyingQuadInstance.Transform;
+			var anchorOffset = QuadMesh.CalculateAnchorOffsetForStandardQuadMesh(new XYPair<float>(curTransform.Scaling.X, curTransform.Scaling.Y), quad.PositionAnchor);
+			if (!TryCalculateCameraLockedTransform(curTransform, anchorOffset, Direction.Forward, quad.LockedAxis, cameraPosition, cameraUpDirection, out var newTransform)) continue;
+			quad.UnderlyingQuadInstance.SetTransform(newTransform);
 		}
-		
-		foreach (var text in _cameraLockedTextInstanceMap[handle]) {
-			text.SetTransform(
+
+		foreach (var text in lockedTextSet) {
+			var curTransform = text.UnderlyingTextInstance.Transform;
+			var @string = text.UnderlyingTextInstance.String;
+			var anchorOffset = @string.Font.GetTextInstanceAnchorOffset(@string.Size, new XYPair<float>(curTransform.Scaling.X, curTransform.Scaling.Y), text.PositionAnchor);
+			if (!TryCalculateCameraLockedTransform(curTransform, anchorOffset, Direction.Backward, text.LockedAxis, cameraPosition, cameraUpDirection, out var newTransform)) continue;
+			text.UnderlyingTextInstance.SetTransform(newTransform);
 		}
+	}
+
+	// The invariant "Translation == anchor world position + (anchorOffsetMeshSpace * Rotation)" is established
+	// by the creation-time transform calculators and re-established here every tick; the camera-locked wrapper
+	// structs expose no rotation/raw-transform setters, so the stored transform is always component-form
+	internal static bool TryCalculateCameraLockedTransform(in Transform currentTransform, Vect anchorOffsetMeshSpace, Direction canonicalFacingDirection, Direction lockedAxis, Location cameraPosition, Direction cameraUpDirection, out Transform result) {
+		var anchorPosition = currentTransform.Translation - anchorOffsetMeshSpace * currentTransform.Rotation;
+		var directionToCamera = anchorPosition.AsLocation().DirectionTo(cameraPosition);
+		if (directionToCamera == Direction.None) {
+			result = currentTransform;
+			return false;
+		}
+
+		Direction facingDirection, uprightDirection;
+		if (lockedAxis == Direction.None) {
+			facingDirection = directionToCamera;
+			uprightDirection = cameraUpDirection.OrthogonalizedAgainst(facingDirection) ?? facingDirection.AnyOrthogonal();
+		}
+		else {
+			var orthogonalizedFacing = directionToCamera.OrthogonalizedAgainst(lockedAxis);
+			if (orthogonalizedFacing is null) {
+				result = currentTransform;
+				return false;
+			}
+			facingDirection = orthogonalizedFacing.Value;
+			uprightDirection = lockedAxis;
+		}
+
+		var rotation = Rotation.FromStartAndEndOrientation(canonicalFacingDirection, Direction.Up, facingDirection, uprightDirection);
+		result = new Transform(
+			translation: anchorPosition + anchorOffsetMeshSpace * rotation,
+			rotation: rotation,
+			scaling: currentTransform.Scaling
+		);
+		return true;
 	}
 	#endregion
 

--- a/TinyFFR/World/LocalSceneBuilder.cs
+++ b/TinyFFR/World/LocalSceneBuilder.cs
@@ -4,6 +4,8 @@
 using System;
 using Egodystonic.TinyFFR.Assets.Local;
 using Egodystonic.TinyFFR.Assets.Materials;
+using Egodystonic.TinyFFR.Assets.Meshes;
+using Egodystonic.TinyFFR.Assets.Text;
 using Egodystonic.TinyFFR.Factory.Local;
 using Egodystonic.TinyFFR.Interop;
 using Egodystonic.TinyFFR.Rendering;
@@ -20,11 +22,15 @@ sealed unsafe class LocalSceneBuilder : ISceneBuilder, ISceneImplProvider, IReso
 	const string BuiltInBackdropNameSuffix = "'";
 	
 	readonly ArrayPoolBackedVector<ResourceHandle<Scene>> _activeSceneHandles = new();
-	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, ArrayPoolBackedVector<ModelInstance>> _modelInstanceMap = new();
-	readonly VectorPool<ModelInstance> _modelInstanceVectorPool;
-	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, ArrayPoolBackedVector<Light>> _lightMap = new();
+	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, ArrayPoolBackedSet<ModelInstance>> _modelInstanceMap = new();
+	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, ArrayPoolBackedSet<QuadInstance>> _cameraLockedQuadInstanceMap = new();
+	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, ArrayPoolBackedSet<TextInstance>> _cameraLockedTextInstanceMap = new();
+	readonly SetPool<ModelInstance> _modelInstanceSetPool;
+	readonly SetPool<QuadInstance> _quadInstanceSetPool;
+	readonly SetPool<TextInstance> _textInstanceSetPool;
+	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, ArrayPoolBackedSet<Light>> _lightMap = new();
 	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, Quality> _shadowQualityActivePresetMap = new();
-	readonly VectorPool<Light> _lightVectorPool;
+	readonly SetPool<Light> _lightSetPool;
 	readonly ArrayPoolBackedMap<ResourceHandle<Scene>, BackdropData> _backdropMap = new();
 	readonly LocalFactoryGlobalObjectGroup _globals;
 	readonly ArrayPoolBackedMap<BuiltInSceneBackdrop, BackdropTexture> _loadedBuiltInBackdropTextures = new();
@@ -37,8 +43,10 @@ sealed unsafe class LocalSceneBuilder : ISceneBuilder, ISceneImplProvider, IReso
 
 		_globals = globals;
 		_assetLoader = assetLoader;
-		_modelInstanceVectorPool = new(zeroMemoryOnReturn: false);
-		_lightVectorPool = new(zeroMemoryOnReturn: false);
+		_modelInstanceSetPool = new(zeroMemoryOnReturn: false);
+		_quadInstanceSetPool = new(zeroMemoryOnReturn: false);
+		_textInstanceSetPool = new(zeroMemoryOnReturn: false);
+		_lightSetPool = new(zeroMemoryOnReturn: false);
 	}
 
 	public Scene CreateScene(in SceneCreationConfig config) {
@@ -48,8 +56,10 @@ sealed unsafe class LocalSceneBuilder : ISceneBuilder, ISceneImplProvider, IReso
 		).ThrowIfFailure();
 
 		_activeSceneHandles.Add(handle);
-		_modelInstanceMap.Add(handle, _modelInstanceVectorPool.Rent());
-		_lightMap.Add(handle, _lightVectorPool.Rent());
+		_modelInstanceMap.Add(handle, _modelInstanceSetPool.Rent());
+		_cameraLockedQuadInstanceMap.Add(handle, _quadInstanceSetPool.Rent());
+		_cameraLockedTextInstanceMap.Add(handle, _textInstanceSetPool.Rent());
+		_lightMap.Add(handle, _lightSetPool.Rent());
 
 		_globals.StoreResourceNameOrDefaultIfEmpty(new ResourceHandle<Scene>(handle).Ident, config.Name, DefaultSceneName);
 
@@ -128,7 +138,7 @@ sealed unsafe class LocalSceneBuilder : ISceneBuilder, ISceneImplProvider, IReso
 			if (s.Implementation is not LocalSceneBuilder lsb) throw new InvalidOperationException();
 			var h = s.GetHandleWithoutDisposeCheck();
 			lsb.ThrowIfThisOrHandleIsDisposed(h);
-			return lsb._modelInstanceMap[h][index];
+			return lsb._modelInstanceMap[h].GetItemAtIndex(index);
 		}
 
 		return new IndirectEnumerable<Scene, ModelInstance>(
@@ -217,7 +227,7 @@ sealed unsafe class LocalSceneBuilder : ISceneBuilder, ISceneImplProvider, IReso
 			if (s.Implementation is not LocalSceneBuilder lsb) throw new InvalidOperationException();
 			var h = s.GetHandleWithoutDisposeCheck();
 			lsb.ThrowIfThisOrHandleIsDisposed(h);
-			return lsb._lightMap[h][index];
+			return lsb._lightMap[h].GetItemAtIndex(index);
 		}
 
 		return new IndirectEnumerable<Scene, Light>(
@@ -360,6 +370,18 @@ sealed unsafe class LocalSceneBuilder : ISceneBuilder, ISceneImplProvider, IReso
 		if (curBackdropData.BackdropTex is { } backdropTex) _globals.DependencyTracker.DeregisterDependency(HandleToInstance(handle), backdropTex);
 	}
 	#endregion
+	
+	#region Camera-Locked Objects
+	public void PrepareCameraLockedObjectsForRender(ResourceHandle<Scene> handle, Camera targetCamera) {
+		foreach (var quad in _cameraLockedQuadInstanceMap[handle]) {
+			quad.
+		}
+		
+		foreach (var text in _cameraLockedTextInstanceMap[handle]) {
+			text.SetTransform(
+		}
+	}
+	#endregion
 
 	public void RemoveAll(ResourceHandle<Scene> handle, bool includeModelInstances, bool includeLights) {
 		ThrowIfThisOrHandleIsDisposed(handle);
@@ -375,6 +397,8 @@ sealed unsafe class LocalSceneBuilder : ISceneBuilder, ISceneImplProvider, IReso
 			}
 			
 			modelInstanceVector.Clear();
+			_cameraLockedQuadInstanceMap[handle].Clear();
+			_cameraLockedTextInstanceMap[handle].Clear();
 		}
 		if (includeLights) {
 			var lightInstanceVector = _lightMap[handle];
@@ -514,7 +538,11 @@ sealed unsafe class LocalSceneBuilder : ISceneBuilder, ISceneImplProvider, IReso
 			while (_activeSceneHandles.Count > 0) Dispose(_activeSceneHandles[^1]);
 
 			_modelInstanceMap.Dispose();
-			_modelInstanceVectorPool.Dispose();
+			_cameraLockedQuadInstanceMap.Dispose();
+			_cameraLockedTextInstanceMap.Dispose();
+			_modelInstanceSetPool.Dispose();
+			_quadInstanceSetPool.Dispose();
+			_textInstanceSetPool.Dispose();
 			
 			foreach (var builtInBackdropTex in _loadedBuiltInBackdropTextures.Values) {
 				builtInBackdropTex.Dispose();
@@ -523,7 +551,7 @@ sealed unsafe class LocalSceneBuilder : ISceneBuilder, ISceneImplProvider, IReso
 			_loadedBuiltInBackdropTextures.Dispose();
 			_backdropMap.Dispose();
 			_lightMap.Dispose();
-			_lightVectorPool.Dispose();
+			_lightSetPool.Dispose();
 			_shadowQualityActivePresetMap.Dispose();
 
 			_activeSceneHandles.Dispose();
@@ -547,10 +575,14 @@ sealed unsafe class LocalSceneBuilder : ISceneBuilder, ISceneImplProvider, IReso
 		
 		_backdropMap.Remove(handle);
 
-		_modelInstanceVectorPool.Return(_modelInstanceMap[handle]);
+		_modelInstanceSetPool.Return(_modelInstanceMap[handle]);
 		_modelInstanceMap.Remove(handle);
+		_quadInstanceSetPool.Return(_cameraLockedQuadInstanceMap[handle]);
+		_cameraLockedQuadInstanceMap.Remove(handle);
+		_textInstanceSetPool.Return(_cameraLockedTextInstanceMap[handle]);
+		_cameraLockedTextInstanceMap.Remove(handle);
 
-		_lightVectorPool.Return(_lightMap[handle]);
+		_lightSetPool.Return(_lightMap[handle]);
 		_lightMap.Remove(handle);
 		
 		_activeSceneHandles.Remove(handle);

--- a/TinyFFR/World/Objects/IObjectBuilder.cs
+++ b/TinyFFR/World/Objects/IObjectBuilder.cs
@@ -133,20 +133,21 @@ public interface IObjectBuilder {
 			mesh,
 			material,
 			lockedAxis ?? Direction.None,
+			positionAnchor,
 			new ModelInstanceCreationConfig {
 				InitialTransform = QuadMesh.CalculateTransformForStandardQuadMesh(
-					position ?? Location.Origin, 
-					size ?? XYPair<float>.One, 
-					Direction.Forward, 
-					Direction.Up, 
+					position ?? Location.Origin,
+					size ?? XYPair<float>.One,
+					Direction.Forward,
+					Direction.Up,
 					positionAnchor
 				),
 				Name = name
 			}
 		);
 	}
-	CameraLockedQuadInstance CreateCameraLockedQuadInstance(QuadMesh mesh, Material material, Direction lockedAxis, in ModelInstanceCreationConfig config) {
-		return new CameraLockedQuadInstance(CreateQuadInstance(mesh, material, in config), lockedAxis);
+	CameraLockedQuadInstance CreateCameraLockedQuadInstance(QuadMesh mesh, Material material, Direction lockedAxis, Orientation2D positionAnchor, in ModelInstanceCreationConfig config) {
+		return new CameraLockedQuadInstance(CreateQuadInstance(mesh, material, in config), lockedAxis, positionAnchor);
 	}
 	#endregion
 	
@@ -179,6 +180,22 @@ public interface IObjectBuilder {
 	TextInstance CreateTextInstance(FontPen pen, FontString @string, in ModelInstanceCreationConfig config) {
 		var underlyingInstance = CreateModelInstance(@string.GetStringMesh(), pen.GetPenMaterial(), in config);
 		return new TextInstance(underlyingInstance, pen, @string);
+	}
+
+	CameraLockedTextInstance CreateCameraLockedTextInstance(FontPen pen, FontString @string, Location? position = null, float? textInstanceHeight = null, float? textInstanceWidth = null, Direction? lockedAxis = null, Orientation2D positionAnchor = Orientation2D.None, bool rescaleHeightAccordingToLineCount = true, ReadOnlySpan<char> name = default) {
+		return CreateCameraLockedTextInstance(
+			pen,
+			@string,
+			lockedAxis ?? Direction.None,
+			positionAnchor,
+			new ModelInstanceCreationConfig {
+				Name = name,
+				InitialTransform = @string.Font.GetTextInstanceTransform(@string.Size, position ?? Location.Origin, Direction.Backward, textInstanceHeight, textInstanceWidth, Direction.Up, positionAnchor, rescaleHeightAccordingToLineCount)
+			}
+		);
+	}
+	CameraLockedTextInstance CreateCameraLockedTextInstance(FontPen pen, FontString @string, Direction lockedAxis, Orientation2D positionAnchor, in ModelInstanceCreationConfig config) {
+		return new CameraLockedTextInstance(CreateTextInstance(pen, @string, in config), lockedAxis, positionAnchor);
 	}
 	#endregion
 }

--- a/TinyFFR/World/Objects/IObjectBuilder.cs
+++ b/TinyFFR/World/Objects/IObjectBuilder.cs
@@ -127,6 +127,27 @@ public interface IObjectBuilder {
 	QuadInstance CreateQuadInstance(QuadMesh mesh, Material material, in ModelInstanceCreationConfig config) {
 		return new QuadInstance(CreateModelInstance(mesh.UnderlyingMesh, material, in config));
 	}
+	
+	CameraLockedQuadInstance CreateCameraLockedQuadInstance(QuadMesh mesh, Material material, Location? position = null, XYPair<float>? size = null, Direction? lockedAxis = null, Orientation2D positionAnchor = Orientation2D.None, ReadOnlySpan<char> name = default) {
+		return CreateCameraLockedQuadInstance(
+			mesh,
+			material,
+			lockedAxis ?? Direction.None,
+			new ModelInstanceCreationConfig {
+				InitialTransform = QuadMesh.CalculateTransformForStandardQuadMesh(
+					position ?? Location.Origin, 
+					size ?? XYPair<float>.One, 
+					Direction.Forward, 
+					Direction.Up, 
+					positionAnchor
+				),
+				Name = name
+			}
+		);
+	}
+	CameraLockedQuadInstance CreateCameraLockedQuadInstance(QuadMesh mesh, Material material, Direction lockedAxis, in ModelInstanceCreationConfig config) {
+		return new CameraLockedQuadInstance(CreateQuadInstance(mesh, material, in config), lockedAxis);
+	}
 	#endregion
 	
 	#region MutableGridMesh

--- a/TinyFFR/World/Scene.cs
+++ b/TinyFFR/World/Scene.cs
@@ -85,6 +85,16 @@ public readonly struct Scene : IDisposableResource<Scene, ISceneImplProvider> {
 	public void Add(TextInstance text) => Add(text.UnderlyingModelInstance);
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Remove(TextInstance text) => Remove(text.UnderlyingModelInstance);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Add(CameraLockedQuadInstance quad) => Implementation.Add(_handle, quad);
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Remove(CameraLockedQuadInstance quad) => Implementation.Remove(_handle, quad);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Add(CameraLockedTextInstance text) => Implementation.Add(_handle, text);
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Remove(CameraLockedTextInstance text) => Implementation.Remove(_handle, text);
 	
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void RemoveAll(bool includeModelInstances = true, bool includeLights = true) => Implementation.RemoveAll(_handle, includeModelInstances, includeLights);

--- a/TinyFFR/World/Scene.cs
+++ b/TinyFFR/World/Scene.cs
@@ -72,19 +72,19 @@ public readonly struct Scene : IDisposableResource<Scene, ISceneImplProvider> {
 	public void Remove<TLight>(TLight light) where TLight : ILight<TLight> => Implementation.Remove(_handle, light);
 	
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Add(QuadInstance quadInstance) => Add(quadInstance.UnderlyingModelInstance);
+	public void Add(QuadInstance quad) => Add(quad.UnderlyingModelInstance);
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Remove(QuadInstance quadInstance) => Remove(quadInstance.UnderlyingModelInstance);
+	public void Remove(QuadInstance quad) => Remove(quad.UnderlyingModelInstance);
 	
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Add(MutableGridInstance quadInstance) => Add(quadInstance.UnderlyingModelInstance);
+	public void Add(MutableGridInstance grid) => Add(grid.UnderlyingModelInstance);
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Remove(MutableGridInstance quadInstance) => Remove(quadInstance.UnderlyingModelInstance);
+	public void Remove(MutableGridInstance grid) => Remove(grid.UnderlyingModelInstance);
 	
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Add(TextInstance quadInstance) => Add(quadInstance.UnderlyingModelInstance);
+	public void Add(TextInstance text) => Add(text.UnderlyingModelInstance);
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Remove(TextInstance quadInstance) => Remove(quadInstance.UnderlyingModelInstance);
+	public void Remove(TextInstance text) => Remove(text.UnderlyingModelInstance);
 	
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void RemoveAll(bool includeModelInstances = true, bool includeLights = true) => Implementation.RemoveAll(_handle, includeModelInstances, includeLights);


### PR DESCRIPTION
Implements per-frame camera-locking (billboarding) for `QuadInstance` and `TextInstance` on top of the groundwork in `feature/PrimitivesRendering`.

## Design
The wrapper structs `CameraLockedQuadInstance` / `CameraLockedTextInstance` deliberately expose **no rotation or raw-transform setters** — only Position/Scaling/Material/Pen/String. The scene therefore owns rotation outright and the stored transform is guaranteed component-form (never matrix-represented), which is what makes the per-frame rotation rewrite safe.

- **Pivot = anchor point**: the tick keeps the anchor's world position invariant (`translation = anchor + offset * rotation` is inverted with the current rotation and re-applied with the new one), so anchored quads/text don't orbit their bottom-left mesh origin. Both wrappers carry their `Orientation2D PositionAnchor` for this.
- **Facing modes**: `LockedAxis == Direction.None` ⇒ spherical billboard facing the camera position (roll fixed by camera up); otherwise cylindrical rotation about the axis.
- **Degenerate configs** (camera at the anchor; camera along the locked axis) skip that instance's update for the frame.
- Zero GC: pooled `ArrayPoolBackedSet`s + pure struct math; early-out when a scene has no locked objects.

## Changes
- `QuadMesh`: `CalculateAnchorOffsetForStandardQuadMesh` extracted; `CameraLockedQuadInstance.PositionAnchor` added
- `LocalFontLoader`/`IFontImplProvider`/`Font`: `GetTextInstanceAnchorOffset` extracted from `GetTextInstanceTransform` (recomputed per tick so string swaps stay correct)
- `IObjectBuilder`: `CreateCameraLockedTextInstance` pair added; quad creation passes the anchor through
- `Scene`/`ISceneImplProvider`: `Add`/`Remove` overloads for both locked types; removing the underlying `ModelInstance` also evicts from the locked sets
- `LocalSceneBuilder`: billboard tick in `PrepareCameraLockedObjectsForRender` with the math in an internal static pure method for testability
- `LocalRendererBuilder.SetUpSceneForRender`: prepares locked objects with the renderer's own camera on every render path (incl. compositors)

## Testing
- 7 new unit tests (`CameraLockedObjectsTest`) covering anchor-offset consistency, spherical/cylindrical facing, anchor stationarity across ticks, degenerate skips, and tick stability — all passing
- Full unit suite: **971 passed, 0 failed** (x64 Debug)
- New `[Explicit]` visual test `LocalCameraLockedObjectsTest` (not run; needs a desktop)
- `AssemblyTypeLoadOrder.cs` extended with a stage-3 anchor for the new doubly-nested wrapper structs

Note: the first commit is a baseline snapshot of the uncommitted working-tree groundwork this builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Eb53PJ7oYpNugMGd8JcMm